### PR TITLE
Fetch and load spdx licenses

### DIFF
--- a/alembic/fetch_spdx_licenses.py
+++ b/alembic/fetch_spdx_licenses.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env pkgx uv run
+"""
+SPDX License Fetching Script
+
+Fetches SPDX license data from GitHub and generates SQL INSERT statements
+for the licenses table. Designed to be piped directly to psql.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+def setup_logging() -> logging.Logger:
+    """Set up logging configuration."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        stream=sys.stderr,  # Log to stderr so stdout is clean for SQL
+    )
+    return logging.getLogger(__name__)
+
+
+def fetch_license_directory() -> list[str]:
+    """
+    Fetch the directory listing of SPDX license files from GitHub API.
+    
+    Returns:
+        List of license filenames (without .txt extension)
+        
+    Raises:
+        Exception: If unable to fetch directory listing
+    """
+    api_url = "https://api.github.com/repos/spdx/license-list-data/contents/text"
+    
+    try:
+        req = Request(api_url)
+        req.add_header("User-Agent", "CHAI-OSS-License-Fetcher/1.0")
+        
+        with urlopen(req, timeout=30) as response:
+            data = json.loads(response.read().decode())
+            
+        # Filter for .txt files and exclude deprecated licenses
+        license_files = []
+        for item in data:
+            if (
+                item["type"] == "file"
+                and item["name"].endswith(".txt")
+                and not item["name"].startswith("deprecated_")
+            ):
+                # Remove .txt extension to get license name
+                license_name = item["name"][:-4]
+                license_files.append(license_name)
+                
+        return license_files
+        
+    except (HTTPError, URLError, json.JSONDecodeError) as e:
+        raise Exception(f"Failed to fetch license directory: {e}") from e
+
+
+def fetch_license_text(license_name: str) -> str | None:
+    """
+    Fetch the text content of a specific SPDX license.
+    
+    Args:
+        license_name: Name of the license (without .txt extension)
+        
+    Returns:
+        License text content or None if failed to fetch
+    """
+    raw_url = f"https://raw.githubusercontent.com/spdx/license-list-data/refs/heads/main/text/{license_name}.txt"
+    
+    try:
+        req = Request(raw_url)
+        req.add_header("User-Agent", "CHAI-OSS-License-Fetcher/1.0")
+        
+        with urlopen(req, timeout=30) as response:
+            return response.read().decode("utf-8")
+            
+    except (HTTPError, URLError, UnicodeDecodeError) as e:
+        logging.warning(f"Failed to fetch license {license_name}: {e}")
+        return None
+
+
+def escape_sql_string(text: str) -> str:
+    """Escape single quotes in SQL string values."""
+    return text.replace("'", "''")
+
+
+def generate_license_sql(licenses: dict[str, str]) -> str:
+    """
+    Generate SQL INSERT statements for licenses.
+    
+    Args:
+        licenses: Dictionary mapping license names to their text content
+        
+    Returns:
+        SQL INSERT statement with ON CONFLICT handling
+    """
+    if not licenses:
+        return "-- No licenses to insert\n"
+        
+    values = []
+    for name, text in licenses.items():
+        escaped_name = escape_sql_string(name)
+        escaped_text = escape_sql_string(text)
+        values.append(f"('{escaped_name}', '{escaped_text}')")
+    
+    values_clause = ",\n".join(values)
+    
+    return f"""-- SPDX License data
+INSERT INTO "licenses" ("name", "text") VALUES
+{values_clause}
+ON CONFLICT (name) DO UPDATE SET 
+    text = EXCLUDED.text,
+    updated_at = NOW();
+"""
+
+
+def main() -> None:
+    """Main function to fetch SPDX licenses and output SQL."""
+    logger = setup_logging()
+    
+    try:
+        logger.info("Fetching SPDX license directory...")
+        license_names = fetch_license_directory()
+        logger.info(f"Found {len(license_names)} licenses to process")
+        
+        licenses = {}
+        failed_count = 0
+        
+        for license_name in license_names:
+            logger.info(f"Fetching license: {license_name}")
+            license_text = fetch_license_text(license_name)
+            
+            if license_text is not None:
+                licenses[license_name] = license_text
+            else:
+                failed_count += 1
+        
+        logger.info(f"Successfully fetched {len(licenses)} licenses, {failed_count} failed")
+        
+        # Generate and output SQL
+        sql = generate_license_sql(licenses)
+        print(sql)  # Print to stdout for piping to psql
+        
+        if failed_count > 0:
+            logger.warning(f"Failed to fetch {failed_count} licenses")
+            
+    except Exception as e:
+        logger.error(f"License fetching failed: {e}")
+        # Output a comment so psql doesn't fail
+        print("-- SPDX license fetching failed, continuing with migration")
+        sys.exit(0)  # Don't fail the migration
+
+
+if __name__ == "__main__":
+    main()

--- a/alembic/run_migrations.sh
+++ b/alembic/run_migrations.sh
@@ -36,4 +36,12 @@ fi
 echo "Loading initial values into the database..."
 psql -U postgres -h "$CHAI_DATABASE_URL" -d chai -f load-values.sql -a
 
+# Fetch and load SPDX licenses
+echo "Fetching and loading SPDX licenses..."
+if python fetch_spdx_licenses.py | psql -U postgres -h "$CHAI_DATABASE_URL" -d chai -a; then
+    echo "SPDX licenses loaded successfully"
+else
+    echo "Warning: SPDX license loading failed, but continuing with migration"
+fi
+
 echo "Database setup and initialization complete"

--- a/alembic/versions/20250821_2148-add_text_field_to_licenses_table.py
+++ b/alembic/versions/20250821_2148-add_text_field_to_licenses_table.py
@@ -1,0 +1,30 @@
+"""add text field to licenses table
+
+Revision ID: b1e2c3d4e5f6
+Revises: 3de32bb99a71
+Create Date: 2025-08-21 21:48:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy import Text
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b1e2c3d4e5f6"
+down_revision: str | None = "3de32bb99a71"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add text field to licenses table to store license content."""
+    op.add_column("licenses", sa.Column("text", Text, nullable=True))
+
+
+def downgrade() -> None:
+    """Remove text field from licenses table."""
+    op.drop_column("licenses", "text")

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     Integer,
     MetaData,
     String,
+    Text,
     UniqueConstraint,
     func,
 )
@@ -158,6 +159,7 @@ class License(Base):
         server_default=func.uuid_generate_v4(),
     )
     name = Column(String, nullable=False, unique=True, index=True)
+    text = Column(Text, nullable=True)
     created_at = Column(
         DateTime, nullable=False, default=func.now(), server_default=func.now()
     )


### PR DESCRIPTION
Integrate automatic SPDX license data fetching into the database initialization pipeline.

This ensures the `licenses` table is automatically populated with the latest SPDX license texts whenever the `alembic` service runs from a fresh start, providing up-to-date license information without manual intervention.

---
<a href="https://cursor.com/background-agent?bcId=bc-47d6db77-921b-470b-b227-32cf3c1cbfe3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-47d6db77-921b-470b-b227-32cf3c1cbfe3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `text` field to the `licenses` table to store license content, adds a script to fetch SPDX licenses from GitHub, and updates migration scripts accordingly.

### Detailed summary
- Added a `text` column to the `licenses` table in `core/models/__init__.py`.
- Created `alembic/versions/20250821_2148-add_text_field_to_licenses_table.py` for migration.
- Implemented `fetch_spdx_licenses.py` to retrieve SPDX licenses and generate SQL statements.
- Updated `alembic/run_migrations.sh` to include SPDX license fetching.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->